### PR TITLE
NCSD-1942: Changed subscription name

### DIFF
--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -76,7 +76,7 @@
         "functionAppName": "[concat(variables('resourcePrefix'), '-fa')]",
         "functionAppInsightsName": "[concat(variables('functionAppName'), '-ai')]",
         "cmsTopicName": "cms-messages",
-        "cmsSubscriptionName": "job-profile-overview",
+        "cmsSubscriptionName": "job-profile-careerpath",
         "refreshTopicName": "job-profile-refresh"
     },
     "resources": [


### PR DESCRIPTION
Subscription name incorrect: was job-profile-overview, changed to job-profile-careerpath