### PR TITLE
NCSLT-409 implementing HTTP Client Factory changes in additional places

### DIFF
--- a/DFC.App.CareerPath.MessageFunctionApp.UnitTests/DFC.App.CareerPath.MessageFunctionApp.UnitTests.csproj
+++ b/DFC.App.CareerPath.MessageFunctionApp.UnitTests/DFC.App.CareerPath.MessageFunctionApp.UnitTests.csproj
@@ -21,6 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.App.CareerPath.MessageFunctionApp.UnitTests/Services/HttpClientServiceTests.cs
+++ b/DFC.App.CareerPath.MessageFunctionApp.UnitTests/Services/HttpClientServiceTests.cs
@@ -4,6 +4,7 @@ using DFC.App.CareerPath.MessageFunctionApp.Services;
 using DFC.App.CareerPath.MessageFunctionApp.UnitTests.ClientHandlers;
 using DFC.Logger.AppInsights.Contracts;
 using FakeItEasy;
+using Moq;
 using System;
 using System.Net;
 using System.Net.Http;
@@ -17,6 +18,7 @@ namespace DFC.App.CareerPath.MessageFunctionApp.UnitTests.Services
         private readonly SegmentClientOptions options;
         private readonly ILogService logger;
         private readonly ICorrelationIdProvider correlationIdProvider;
+        private Mock<IHttpClientFactory> mockFactory;
 
         public HttpClientServiceTests()
         {
@@ -30,6 +32,13 @@ namespace DFC.App.CareerPath.MessageFunctionApp.UnitTests.Services
             correlationIdProvider = A.Fake<ICorrelationIdProvider>();
         }
 
+        public Mock<IHttpClientFactory> CreateClientFactory(HttpClient httpClient)
+        {
+            mockFactory = new Mock<IHttpClientFactory>();
+            mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            return mockFactory;
+        }
+
         [Fact]
         public async Task PostAsyncReturnsOKStatusCodeWhenHttpResponseIsSuccessful()
         {
@@ -41,7 +50,7 @@ namespace DFC.App.CareerPath.MessageFunctionApp.UnitTests.Services
 
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = new Uri("http://SomeDummyUrl") };
-            var httpClientService = new HttpClientService(options, httpClient, logger, correlationIdProvider);
+            var httpClientService = new HttpClientService(options, CreateClientFactory(httpClient).Object, logger, correlationIdProvider);
 
             // Act
             var result = await httpClientService.PostAsync(GetSegmentModel()).ConfigureAwait(false);
@@ -65,7 +74,7 @@ namespace DFC.App.CareerPath.MessageFunctionApp.UnitTests.Services
 
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = new Uri("http://SomeDummyUrl") };
-            var httpClientService = new HttpClientService(options, httpClient, logger, correlationIdProvider);
+            var httpClientService = new HttpClientService(options, CreateClientFactory(httpClient).Object, logger, correlationIdProvider);
 
             // Act
             await Assert.ThrowsAsync<HttpRequestException>(async () => await httpClientService.PostAsync(GetSegmentModel()).ConfigureAwait(false)).ConfigureAwait(false);
@@ -86,7 +95,7 @@ namespace DFC.App.CareerPath.MessageFunctionApp.UnitTests.Services
 
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = new Uri("http://SomeDummyUrl") };
-            var httpClientService = new HttpClientService(options, httpClient, logger, correlationIdProvider);
+            var httpClientService = new HttpClientService(options, CreateClientFactory(httpClient).Object, logger, correlationIdProvider);
 
             // Act
             await Assert.ThrowsAsync<HttpRequestException>(async () => await httpClientService.PutAsync(GetSegmentModel()).ConfigureAwait(false)).ConfigureAwait(false);
@@ -107,7 +116,7 @@ namespace DFC.App.CareerPath.MessageFunctionApp.UnitTests.Services
 
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = new Uri("http://SomeDummyUrl") };
-            var httpClientService = new HttpClientService(options, httpClient, logger, correlationIdProvider);
+            var httpClientService = new HttpClientService(options, CreateClientFactory(httpClient).Object, logger, correlationIdProvider);
 
             // Act
             var result = await httpClientService.PutAsync(GetSegmentModel()).ConfigureAwait(false);
@@ -131,7 +140,7 @@ namespace DFC.App.CareerPath.MessageFunctionApp.UnitTests.Services
 
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = new Uri("http://SomeDummyUrl") };
-            var httpClientService = new HttpClientService(options, httpClient, logger, correlationIdProvider);
+            var httpClientService = new HttpClientService(options, CreateClientFactory(httpClient).Object, logger, correlationIdProvider);
 
             // Act
             var result = await httpClientService.PutAsync(GetSegmentModel()).ConfigureAwait(false);
@@ -155,7 +164,7 @@ namespace DFC.App.CareerPath.MessageFunctionApp.UnitTests.Services
 
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = new Uri("http://SomeDummyUrl") };
-            var httpClientService = new HttpClientService(options, httpClient, logger, correlationIdProvider);
+            var httpClientService = new HttpClientService(options, CreateClientFactory(httpClient).Object, logger, correlationIdProvider);
 
             // Act
             var result = await httpClientService.DeleteAsync(Guid.NewGuid()).ConfigureAwait(false);
@@ -179,7 +188,7 @@ namespace DFC.App.CareerPath.MessageFunctionApp.UnitTests.Services
 
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = new Uri("http://SomeDummyUrl") };
-            var httpClientService = new HttpClientService(options, httpClient, logger, correlationIdProvider);
+            var httpClientService = new HttpClientService(options, CreateClientFactory(httpClient).Object, logger, correlationIdProvider);
 
             // Act
             await Assert.ThrowsAsync<HttpRequestException>(async () => await httpClientService.DeleteAsync(Guid.NewGuid()).ConfigureAwait(false)).ConfigureAwait(false);

--- a/DFC.App.CareerPath.MessageFunctionApp/Services/HttpClientService.cs
+++ b/DFC.App.CareerPath.MessageFunctionApp/Services/HttpClientService.cs
@@ -18,10 +18,10 @@ namespace DFC.App.CareerPath.MessageFunctionApp.Services
         private readonly ILogService logger;
         private readonly ICorrelationIdProvider correlationIdProvider;
 
-        public HttpClientService(SegmentClientOptions segmentClientOptions, HttpClient httpClient, ILogService logger, ICorrelationIdProvider correlationIdProvider)
+        public HttpClientService(SegmentClientOptions segmentClientOptions, IHttpClientFactory httpClientFactory, ILogService logger, ICorrelationIdProvider correlationIdProvider)
         {
             this.segmentClientOptions = segmentClientOptions;
-            this.httpClient = httpClient;
+            this.httpClient = httpClientFactory.CreateClient();
             this.logger = logger;
             this.correlationIdProvider = correlationIdProvider;
         }

--- a/DFC.App.CareerPath.MessageFunctionApp/Startup.cs
+++ b/DFC.App.CareerPath.MessageFunctionApp/Startup.cs
@@ -38,7 +38,7 @@ namespace DFC.App.CareerPath.MessageFunctionApp
             services.AddAutoMapper(typeof(Startup).Assembly);
             services.AddScoped<IMessagePreProcessor, MessagePreProcessor>();
             services.AddScoped<IMessageProcessor, MessageProcessor>();
-            services.AddTransient(provider => new HttpClient());
+            services.AddHttpClient();
             services.AddScoped<IHttpClientService, HttpClientService>();
             services.AddSingleton<IMappingService, MappingService>();
             services.AddSingleton<IMessagePropertiesService, MessagePropertiesService>();


### PR DESCRIPTION
Use IHttpClientFactory instead of instantiating HttpClient class for each request.